### PR TITLE
Add scheme if missing

### DIFF
--- a/lib/src/main/java/org/buffer/sociallinkify/span/ClickableUrlSpan.kt
+++ b/lib/src/main/java/org/buffer/sociallinkify/span/ClickableUrlSpan.kt
@@ -11,7 +11,11 @@ abstract class ClickableUrlSpan(url: String) : URLSpan(url) {
 
     override fun onClick(widget: View) {
         try {
-            CustomTabUtil.open(widget.context, Uri.parse(url))
+            if (url.contains(":")) {
+                CustomTabUtil.open(widget.context, Uri.parse(url))
+            } else {
+                CustomTabUtil.open(widget.context, Uri.parse("http://$url"))
+            }
         } catch (exception: ActivityNotFoundException) {
             Log.e(ClickableUrlSpan::class.java.simpleName,
                 "Whoops, that doesn't look like a valid URL.")

--- a/lib/src/main/java/org/buffer/sociallinkify/span/ClickableUrlSpan.kt
+++ b/lib/src/main/java/org/buffer/sociallinkify/span/ClickableUrlSpan.kt
@@ -14,7 +14,7 @@ abstract class ClickableUrlSpan(url: String) : URLSpan(url) {
             if (url.contains(":")) {
                 CustomTabUtil.open(widget.context, Uri.parse(url))
             } else {
-                CustomTabUtil.open(widget.context, Uri.parse("http://$url"))
+                CustomTabUtil.open(widget.context, Uri.parse("https://$url"))
             }
         } catch (exception: ActivityNotFoundException) {
             Log.e(ClickableUrlSpan::class.java.simpleName,


### PR DESCRIPTION
CustomTabs and Intent.ACTION_VIEW cannot open urls that don't have a schema (`http`, for example). This checks for a scheme, using a conservative match for `":"`, and adds a schema before opening if it is missing.

I am matching for `:` only right now to account for schemas from `https://` to `mailto:`, etc.

I looked at `android.text.util.Linkify`, and it uses a similar approach to this one:
- matches the URL
- checks for the schema (`"http://", "https://", "rtsp://"` for web urls, `"mailto:"`, etc)
- prepends the first of the listed scheme to the url if it's missing (`"http://"` for web urls, `"mailto:"`, etc)

The approach I added is lex complex, but more strict. I think it should work for the application of this library.