### PR TITLE
Allow _ and . character in @ mentions

### DIFF
--- a/lib/src/main/java/org/buffer/sociallinkify/SocialLinkify.kt
+++ b/lib/src/main/java/org/buffer/sociallinkify/SocialLinkify.kt
@@ -24,7 +24,7 @@ object SocialLinkify {
     val URL_BASE_HASHTAG_FACEBOOK = "https://www.facebook.com/hashtag/"
 
     private val hashtagPattern = Pattern.compile("#(\\w+)")
-    private val mentionPattern = Pattern.compile("@(\\w+)")
+    private val mentionPattern = Pattern.compile("@([a-zA-Z0-9._]+)")
     private val urlPattern = Patterns.WEB_URL
     private val emailPattern = Patterns.EMAIL_ADDRESS
 


### PR DESCRIPTION
It looks like for IG mentions, not all usernames as being accounted for. This change allows for `_` and `.` characters within usernames so that they can be highlighted correctly